### PR TITLE
Allow identifier to start with a number

### DIFF
--- a/fasm.tx
+++ b/fasm.tx
@@ -6,7 +6,7 @@ S: /[ \t]/ ;
 
 Newline: /[\n\r]/ ;
 
-Identifier: /[a-zA-Z][0-9a-zA-Z_]*/ ;
+Identifier: /[0-9a-zA-Z_]*/ ;
 Feature: Identifier ( '.' Identifier )* ;
 
 DecimalValue: /[0-9_]+/ ;


### PR DESCRIPTION
PRECYINIT are named as e.g. CLBLL_L.SLICEL_X0.PRECYINIT.0, so
limiting the identifier to start with a letter was breaking the flow
