### PR TITLE
docs: Small corrections in FASM specification

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -10,7 +10,7 @@ A FASM file declares that specific "Features" within the bitstream should be ena
 
 A FASM file is illegal if a bit in the final bitstream must be set and cleared to respect the set of features specified in the FASM file.
 
-An empty FASM file will generate a platform specific "default" bitstream. The FASM file will specific zero or more features that mutate the "default" bitstream into the target bitstream.
+An empty FASM file will generate a platform specific "default" bitstream. The FASM file will specify zero or more features that mutate the "default" bitstream into the target bitstream.
 
 File Syntax description
 -----------------------


### PR DESCRIPTION
Small corrections derived from the `fasm_specification.rst` in the PR (https://github.com/SymbiFlow/symbiflow-docs/pull/9) which will be replaced in symbiflow-docs with a link to the `specification.rst` in this repository.