### PR TITLE
Fix calls in conf.py that have errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,8 +51,3 @@ env:
 	source env/bin/activate; conda env update --name base --file ./environment.yml
 
 .PHONY: env
-
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile links
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,3 +51,8 @@ env:
 	source env/bin/activate; conda env update --name base --file ./environment.yml
 
 .PHONY: env
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%:
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,14 +72,13 @@ else:
     import subprocess
     subprocess.call('git fetch origin --unshallow', cwd=docs_dir, shell=True)
     subprocess.check_call('git fetch origin --tags', cwd=docs_dir, shell=True)
-    subprocess.check_call('make links', cwd=docs_dir, shell=True)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = re.sub('^v', '', os.popen('git describe ').read().strip())
+release = re.sub('^v', '', os.popen('git describe --always').read().strip())
 # The short X.Y version.
 version = release
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ else:
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = re.sub('^v', '', os.popen('git describe --always').read().strip())
+release = re.sub('^v', '', os.popen('git describe').read().strip())
 # The short X.Y version.
 version = release
 


### PR DESCRIPTION
The current rtd build fails because `make links` was called and not defined properly in the Makefile (because I just copied from another repository, my bad). As we don't have any symlinks currently, there is no point in calling `make links` anyways, so I removed it.

Additionally, `git describe` gives an error because there is no version tag for this repository. Change it to `git describe --always` so that it returns the shortened hash of the latest commit as a fallback.

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>