### PR TITLE
Don't install tests into site-packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,5 +19,6 @@ recursive-include docs *.txt
 recursive-include docs *.yml
 recursive-include docs *.png
 recursive-include docs Makefile
+recursive-include tests *
 prune docs/_*
 prune docs/env

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/SymbiFlow/fasm",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=('tests*',)),
     package_data={
         'fasm': ['*.tx'],
     },


### PR DESCRIPTION
Installing the tests into `site-packages` will conflict with any other package that does the same.