### PR TITLE
Update GH actions, test scripts, and supporting files.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -10,14 +10,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install clang-format
           python -m pip install --upgrade pip
-          pip install yapf
+          pip install yapf flake8
       - name: Python style check
         run: |
           make format
@@ -42,6 +42,10 @@ jobs:
             TOXENV: py36
           - python-version: 3.7
             TOXENV: py37
+          - python-version: 3.8
+            TOXENV: py38
+          - python-version: 3.9
+            TOXENV: py39
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -20,16 +20,16 @@ jobs:
           pip install yapf flake8
       - name: Python style check
         run: |
-          make format
+          make format lint
           test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }
       - name: C++ style check
         run: |
           make format-cpp
           test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }
       - name: Check license
-        run: ./.github/check_license.sh
+        run: make check-license
       - name: Python checks
-        run: ./.github/check_python_scripts.sh
+        run: make check-python-scripts
   test:
     name: Test Python package
     runs-on: ubuntu-20.04

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -6,6 +6,9 @@ on: [push, pull_request]
 jobs:
   wheels:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -14,14 +17,18 @@ jobs:
       run: |
         sudo apt update
         sudo apt install cmake default-jre-headless uuid-dev libantlr4-runtime-dev
-    - name: Set up Python 3.x
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: python -m pip install --upgrade setuptools wheel
     - name: Build wheels
       run: python setup.py bdist_wheel
+    - name: Test wheel installation
+      run: |
+        python -m pip install dist/*.whl
+        (cd tests; python test_simple.py)
     - uses: actions/upload-artifact@v2
       with:
         name: fasm

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Emacs temporary files
+*~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,15 @@ recursive-include docs *.yml
 recursive-include docs *.png
 recursive-include docs Makefile
 recursive-include tests *
+prune tests/__pycache__
 prune docs/_*
 prune docs/env
+
+include src/*
+include src/antlr/*
+recursive-include third_party *
+global-exclude .git
+exclude .gitmodules
 exclude .clang-format
+
+recursive-include fasm/parser *.tx

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ build:
 install:
 	python setup.py install
 
+.PHONY: test
+test:
+	py.test -s tests
+
 PYTHON_FORMAT ?= yapf
 format:
 	$(IN_ENV) git ls-files | grep -ve '^third_party\|^\.' | grep -e '.py$$' | xargs -r -P $$(nproc) yapf -p -i
+	flake8 .
 
 check-license:
 	@./.github/check_license.sh

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
+    py39: python3.9
 deps =
     check-manifest
     # If your project uses README.rst, uncomment the following:
@@ -19,9 +21,18 @@ commands =
     # This repository uses a Markdown long_description, so the -r flag to
     # `setup.py check` is not needed. If your project contains a README.rst,
     # use `python setup.py check -m -r -s` instead.
+    python setup.py develop
     python setup.py check -m -s
     flake8 .
-    py.test tests
+    py.test -s tests
+
 [flake8]
-exclude = .tox,*.egg,build,data
+exclude = .tox,*.egg,build,data,third_party
 select = E,W,F
+ignore = W503  # Deprecated warning contradicts W504
+per-file-ignores =
+    __init__.py: F401
+
+[check-manifest]
+ignore =
+    fasm/tags.py


### PR DESCRIPTION
These changes were split out of https://github.com/SymbiFlow/fasm/pull/28.

The major changes are:

* Adding Python 3.8, 3.9 builds
* Clean up Makefile and add some quick checks that I keep forgetting.
* Fixing some other problems with flake8, `MANIFEST.in`, and tox.