### PR TITLE
Fix readthedocs environment.yml file.

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,4 +13,4 @@ dependencies:
 - sphinx_rtd_theme
 # Packages installed from PyPI
 - pip:
-  - -r file:requirements.txt
+  - -r requirements.txt


### PR DESCRIPTION
```
Collecting package metadata: ...working... done
Solving environment: ...working... done
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Ran pip subprocess with arguments:
[u'/home/docs/checkouts/readthedocs.org/user_builds/fasm/conda/78/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/docs/checkouts/readthedocs.org/user_builds/fasm/checkouts/78/docs/tmpAGdqnl.requirements.txt']
Pip subprocess output:

Pip subprocess error:
ERROR: 404 Client Error: FileNotFoundError for url: file:///requirements.txt

CondaEnvException: Pip failed
```

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>