### PR TITLE
Build system fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,8 +121,6 @@ class AntlrCMakeBuild(build_ext):
                             os.path.dirname(self.get_ext_fullpath(ext.name))),
                         ext.prefix)
 
-            super().run()
-
             try:
                 out = subprocess.check_output(['cmake', '--version'])
             except OSError:
@@ -136,8 +134,7 @@ class AntlrCMakeBuild(build_ext):
             if cmake_version < '3.7.0':
                 raise RuntimeError("CMake >= 3.7.0 is required.")
 
-            for ext in self.extensions:
-                self.build_extension(ext)
+            super().run()
 
         except BaseException as e:
             print(

--- a/setup.py
+++ b/setup.py
@@ -168,8 +168,7 @@ class AntlrCMakeBuild(build_ext):
                     os.path.dirname(self.get_ext_fullpath(ext.name))),
                 ext.prefix)
             cmake_args = [
-                '-DCMAKE_INSTALL_PREFIX=' + extdir,
-                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                '-DCMAKE_INSTALL_PREFIX=' + extdir, '-DCMAKE_INSTALL_LIBDIR=.',
                 '-DPYTHON_EXECUTABLE=' + sys.executable,
                 '-DANTLR_RUNTIME_TYPE=' + shared_options.antlr_runtime
             ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(parse_fasm SHARED ParseFasm.cpp
   ${ANTLR_FasmLexer_CXX_OUTPUTS}
   ${ANTLR_FasmParser_CXX_OUTPUTS})
 target_link_libraries(parse_fasm ${ANTLR4_RUNTIME})
+install(TARGETS parse_fasm)
 #target_compile_options(parse_fasm PRIVATE -Wno-attributes) # Disable warning from antlr4-runtime
 
 add_executable(parse_fasm_tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,13 +80,15 @@ antlr_target(FasmParser antlr/FasmParser.g4 PARSER VISITOR
 # line 1: Skip lines starting in #define
 #      2: Extract TAGS(...) from dependencies
 #      3: Convert from TAGS('c', long_name) -> long_name = b'c, write to file
-add_custom_target(tags.py ALL
+add_custom_command(OUTPUT tags.py
   COMMAND grep -ve ^\#define ${CMAKE_CURRENT_SOURCE_DIR}/ParseFasm.cpp |
           grep -hoe TAG\([^\)]*\) |
-          sed -e s/TAG\(\\\(.*\\\),\ \\\(.*\\\)\)/\\2\ =\ b\\1/ > tags.py
+          sed -e s/TAG\(\\\(.*\\\),\ \\\(.*\\\)\)/\\2\ =\ b\\1/ > ${CMAKE_CURRENT_BINARY_DIR}/tags.py
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ParseFasm.cpp
   VERBATIM
   )
+add_custom_target(tags_py ALL DEPENDS tags.py)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tags.py TYPE LIB)
 
 # Include generated files in project environment
 include_directories(${ANTLR_FasmLexer_OUTPUT_DIR})
@@ -123,5 +125,3 @@ include(CTest)
 add_test(NAME parse_fasm_tests
          COMMAND parse_fasm_tests)
 enable_testing()
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tags.py DESTINATION .)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ include_directories(${ANTLR4_INCLUDE_DIRS})
 
 # set variable pointing to the antlr tool that supports C++
 # this is not required if the jar file can be found under PATH environment
-set(ANTLR_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/antlr4_lib/antlr-4.9.3-complete.jar)
+set(ANTLR_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/antlr4_lib/antlr-4.9.3-complete.jar CACHE PATH "antlr4 generator JAR file")
 
 # add macros to generate ANTLR Cpp code from grammar
 find_package(ANTLR REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(parse_fasm_tests
   ${ANTLR_FasmParser_CXX_OUTPUTS})
 target_link_libraries(parse_fasm_tests ${ANTLR4_RUNTIME})
 target_link_libraries(parse_fasm_tests gtest_main)
+target_link_libraries(parse_fasm_tests gtest)
 #target_compile_options(parse_fasm_tests PRIVATE -Wno-attributes) # Disable warning from antlr4-runtime
 
 # Standalone executable


### PR DESCRIPTION
While packaging fasm for the [AUR](https://aur.archlinux.org/packages/python-fasm-git), I came across a bunch of problems that I hope I'll be able to fix upstream here so others can benefit from the fixes too. These changes shouldn't change anything about the "intended" build workflow, but allow distro packages to build the package according to packaging standards.